### PR TITLE
Improve retry logic

### DIFF
--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -593,7 +593,7 @@ class MQTTThread(weewx.restx.RESTThread):
         
     def prep_data(self, mc, data, topic):
         if self.topics[topic]['aggregation'].find('aggregate') >= 0:
-            self.publish_aggregate_data(mc,
+            self.publish_data(mc,
                                         data,
                                         topic,
                                         self.topics[topic]['qos'],
@@ -601,9 +601,9 @@ class MQTTThread(weewx.restx.RESTThread):
         if self.topics[topic]['aggregation'].find('individual') >= 0:
             for key in data:
                 tpc = topic + '/' + key
-                self.publish_aggregate_data(mc, tpc, data[key], retain=self.topics[topic]['retain'], qos=self.topics[topic]['qos'])
+                self.publish_data(mc, tpc, data[key], retain=self.topics[topic]['retain'], qos=self.topics[topic]['qos'])
 
-    def publish_aggregate_data(self, mc, data, topic, qos, retain):
+    def publish_data(self, mc, data, topic, qos, retain):
         import socket
         for _count in range(self.max_tries):
             try:

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -274,6 +274,9 @@ class MQTT(weewx.restx.StdRESTbase):
             logerr("Data will not be uploaded: Missing option %s" % e)
             return
 
+        if not to_bool(site_dict.get('enable', True)):
+            return
+
         # for backward compatibility: 'units' is now 'unit_system'
         _compat(site_dict, 'units', 'unit_system')
 


### PR DESCRIPTION
- When persistence connection is configured, it will be attempted max_tries and then control is handed back to WeeWX.
- When ‘on demand’ connection, it will be attempted max_tries and then the record/packet is skipped. A single ‘on demand’ connection is used for all publishing for a record/packet.
- Every publish is attempted max_tries. So, when publishing individual topics, each is attempted max_tries.
- Publish retry logic has been added for ‘no connection’ errors.
- Enable option is supported. This still needs to be reworked.
- A flag to run single threaded has been added. This should only be used when developing/debugging.